### PR TITLE
Add Denmark e-invoice regulatory update 20250830-221338

### DIFF
--- a/regulatory-update-20250830-221338.md
+++ b/regulatory-update-20250830-221338.md
@@ -1,0 +1,25 @@
+## Topic
+- denmark e-invoice updates
+
+## Document Metadata
+- Jurisdiction/scope: Denmark [Ref 1][Ref 2]
+
+## Tax & VAT Compliance
+- VAT on certain leisure and educational services will be introduced starting January 1, 2026 [Ref 1].
+  - This includes activities like fitness classes, personal training, dance schools, ceramics, drawing, cooking, and mental sports [Ref 1].
+  - Sports clubs and municipal music schools will remain VAT-free [Ref 1].
+  - Services for children and those under 30 are exempt from the VAT change [Ref 1].
+  - A tax deduction will be available for those aged 30 and above for services newly subject to VAT, starting from the 2026 income year [Ref 1].
+- Denmark plans to abolish the 25% VAT on books [Ref 2].
+  - This is aimed at addressing a reading crisis among children and young people [Ref 2].
+  - Abolishing the VAT could reduce tax revenue by approximately DKK 330 million per year [Ref 2].
+- VAT rates on books in other Nordic countries: Finland (14%), Sweden (6%), and Norway (0%) [Ref 2]. The UK exempts books from VAT [Ref 2].
+
+## Gaps/Unknowns
+- The specific mechanisms for implementing VAT on leisure and educational services are not detailed [Ref 1].
+- The exact date for abolishing VAT on books is not specified [Ref 2].
+- Details on how the government will monitor savings being passed to consumers are not provided [Ref 2].
+
+### Source References
+- [Ref 1] Denmark to Implement VAT on Leisure and Teaching Courses with New Tax Deduction — https://www.vatupdate.com/2025/08/30/denmark-to-implement-vat-on-leisure-and-teaching-courses-with-new-tax-deduction/
+- [Ref 2] Denmark to Abolish 25% VAT on Books to Combat Reading Crisis and Boost Literacy — https://www.vatupdate.com/2025/08/30/denmark-to-abolish-25-vat-on-books-to-combat-reading-crisis-and-boost-literacy-2/


### PR DESCRIPTION
This PR adds regulatory update documentation for Denmark E-invoice (20250830-221338), covering new VAT rules for leisure/educational services and book VAT exemption, including gaps/unknowns and source references.