### PR TITLE
Denmark VAT and e-invoice compliance update (2025-09-01)

### DIFF
--- a/regulatory-update-20250901-105842.md
+++ b/regulatory-update-20250901-105842.md
@@ -1,0 +1,22 @@
+## Topic
+- denmark e-invoice compliance updates
+
+## Document Metadata
+- Jurisdiction/scope: Denmark [Ref 1][Ref 2]
+- Effective/compliance dates: January 1, 2026 (VAT on leisure and teaching courses) [Ref 2]
+
+## Tax & VAT Compliance
+- VAT on books: Denmark plans to abolish the 25% VAT on books [Ref 1]. This could reduce tax revenue by approximately DKK 330 million per year [Ref 1].
+- VAT on leisure and teaching courses: Denmark will introduce VAT on certain leisure and educational services starting January 1, 2026 [Ref 2].
+  - Affected activities include fitness classes, personal training, dance schools, ceramics, drawing, cooking, and mental sports [Ref 2].
+  - Exemptions: Sports clubs and municipal music schools will remain VAT-free [Ref 2]. Services for children and those under 30 are exempt [Ref 2].
+  - Tax deduction: A tax deduction will be available for those aged 30 and above for services newly subject to VAT, starting from the 2026 income year [Ref 2].
+
+## Gaps/Unknowns
+- Details on how the Danish government will monitor the VAT abolishment on books to ensure savings are passed to consumers [Ref 1].
+- Specifics of the tax deduction available for those aged 30 and above for leisure and educational services [Ref 2].
+- Details on e-invoicing compliance updates, as the topic specifies, are not present in the provided sources [Ref 1][Ref 2].
+
+### Source References
+- [Ref 1] Denmark to Abolish 25% VAT on Books to Combat Reading Crisis and Boost Literacy — https://www.vatupdate.com/2025/08/30/denmark-to-abolish-25-vat-on-books-to-combat-reading-crisis-and-boost-literacy-2/
+- [Ref 2] Denmark to Implement VAT on Leisure and Teaching Courses with New Tax Deduction — https://www.vatupdate.com/2025/08/30/denmark-to-implement-vat-on-leisure-and-teaching-courses-with-new-tax-deduction/


### PR DESCRIPTION
This PR adds a regulatory update for Denmark e-invoice compliance and VAT changes, effective January 1, 2026. Includes:

- Abolishment of 25% VAT on books
- VAT introduction on leisure and teaching courses (with key exemptions)
- Notes on gaps/unknowns and references to VATUpdate.com sources

See `regulatory-update-20250901-105842.md` for full details.