### PR TITLE
Regulatory Update: Denmark E-invoicing & VAT Changes (2025-09-01)

### DIFF
--- a/regulatory-update-20250901-135200.md
+++ b/regulatory-update-20250901-135200.md
@@ -1,0 +1,27 @@
+## Topic
+- denmark e-invoicing updates
+
+## Document Metadata
+- Jurisdiction/scope: Denmark [Ref 1][Ref 2]
+
+## Tax & VAT Compliance
+- Denmark plans to abolish the 25% VAT on books [Ref 1].
+    - This is aimed at addressing a reading crisis among children and young people [Ref 1].
+    - The proposal intends to make literature more affordable and invest in education and libraries [Ref 1].
+    - Abolishing the VAT could reduce tax revenue by approximately DKK 330 million per year [Ref 1].
+- VAT on books in other Nordic countries is lower: Finland (14%), Sweden (6%), and Norway (0%) [Ref 1]. The UK exempts books from VAT [Ref 1].
+- Denmark will introduce VAT on certain leisure and educational services starting January 1, 2026 [Ref 2].
+    - This change is due to European Court of Justice rulings [Ref 2].
+    - VAT will apply to activities like fitness classes, personal training, dance schools, ceramics, drawing, cooking, and mental sports [Ref 2].
+    - Sports clubs and municipal music schools will remain VAT-free [Ref 2].
+    - Services for children and those under 30 are exempt from the VAT change [Ref 2].
+    - A tax deduction will be available for those aged 30 and above for services newly subject to VAT [Ref 2].
+    - The tax deduction will be available from the 2026 income year [Ref 2].
+
+## Gaps/Unknowns
+- The sources do not specify how the Danish government will monitor the measure to ensure savings are passed to consumers regarding the VAT abolishment on books [Ref 1].
+- The sources do not specify the exact details of the tax deduction available for those aged 30 and above for leisure and educational services [Ref 2].
+
+### Source References
+- [Ref 1] Denmark to Abolish 25% VAT on Books to Combat Reading Crisis and Boost Literacy — https://www.vatupdate.com/2025/08/30/denmark-to-abolish-25-vat-on-books-to-combat-reading-crisis-and-boost-literacy-2/
+- [Ref 2] Denmark to Implement VAT on Leisure and Teaching Courses with New Tax Deduction — https://www.vatupdate.com/2025/08/30/denmark-to-implement-vat-on-leisure-and-teaching-courses-with-new-tax-deduction/


### PR DESCRIPTION
This PR adds a new regulatory update file for Denmark, covering recent changes in e-invoicing and VAT compliance as of September 2025.

- VAT on books to be abolished (25% → 0%)
- Introduction of VAT on certain leisure and educational services from Jan 1, 2026
- Tax deduction and exemptions detailed
- Sources and gaps/unknowns clearly identified

See `regulatory-update-20250901-135200.md` for details.