### PR TITLE
Regulatory update: Sweden e-invoicing and temporary food VAT change (2026-2027)

### DIFF
--- a/regulatory-update-20250905-080901.md
+++ b/regulatory-update-20250905-080901.md
@@ -1,0 +1,24 @@
+## Topic
+- sweden e-invoicing updates
+
+## Document Metadata
+- Jurisdiction/scope: Sweden [Ref 1][Ref 2]
+- Effective/compliance dates: April 1, 2026 to December 2027 (food VAT reduction) [Ref 1][Ref 2]
+
+## Tax & VAT Compliance
+- VAT rate on foodstuffs will be reduced from 12% to 6% [Ref 1][Ref 2].
+- The reduced rate is temporary, effective from April 1, 2026, to December 2027 [Ref 1][Ref 2].
+- The government will establish a "food commission" to monitor price trends and ensure VAT savings are passed on to consumers [Ref 1][Ref 2].
+
+## Implementation Impact
+- Businesses selling foodstuffs in Sweden will need to adjust their systems to account for the temporary VAT rate change [Ref 1][Ref 2].
+- Retailers should expect increased scrutiny of their pricing practices from the "food commission" [Ref 1][Ref 2].
+
+## Gaps/Unknowns
+- The specific details of how the "food commission" will operate and what metrics it will use to monitor prices are not specified [Ref 1][Ref 2].
+- Details regarding the "income and corporate tax relief" are not available [Ref 1].
+- The exact nature of the "tax cuts" that may be included in the budget are not specified [Ref 2].
+
+### Source References
+- [Ref 1] Sweden to reduce the VAT rate on foodstuffs from 12% to 6% as of 1 April 2026 — https://www.vatupdate.com/2025/09/05/sweden-to-reduce-the-vat-rate-on-foodstuffs-from-12-to-6-as-of-1-april-2026/
+- [Ref 2] Sweden to Halve Food VAT in Election-Year Budget to Boost Economy and Support Households — https://www.vatupdate.com/2025/09/04/sweden-to-halve-food-vat-in-election-year-budget-to-boost-economy-and-support-households/


### PR DESCRIPTION
This pull request adds a regulatory update for Sweden covering the temporary reduction of the VAT rate on foodstuffs from 12% to 6%, effective from April 1, 2026, through December 2027. 

The update outlines:
- The new VAT rates and compliance timeline.
- The planned 'food commission' oversight for price fairness.
- Implementation needs for businesses and retailers.
- Open questions regarding operation details and related tax cuts.

See the new file: `regulatory-update-20250905-080901.md` for details and references.