### PR TITLE
Regulatory update: Sweden e-invoicing (2025-09-15)

### DIFF
--- a/regulatory-update-20250915-100648.md
+++ b/regulatory-update-20250915-100648.md
@@ -1,0 +1,28 @@
+## Topic
+- sweden e-invoicing updates
+
+## Document Metadata
+- Jurisdiction/scope: Sweden [Ref 1].
+
+## Requirements / Specifications
+- PEPPOL BIS Billing 3 is the recommended standard for e-invoicing in Sweden [Ref 1].
+- It is based on the European standard EN 16931 [Ref 1].
+
+## Tax & VAT Compliance
+- E-invoicing is mandatory for all purchases within the public sector in Sweden [Ref 1].
+- This applies to all Swedish government agencies, municipalities, and county councils [Ref 1].
+- Suppliers to the public sector must send e-invoices [Ref 1].
+
+## Submission & Interfaces
+- E-invoices are sent via a PEPPOL access point [Ref 1].
+
+## Implementation Impact
+- Suppliers need to ensure their systems can create and send e-invoices in the PEPPOL BIS Billing 3 format [Ref 1].
+- Public sector entities need to be able to receive and process e-invoices in the PEPPOL BIS Billing 3 format [Ref 1].
+
+## Gaps/Unknowns
+- Details regarding specific data elements, validation rules, or error codes are not provided in the source [Ref 1].
+- Specifics about API endpoints, authentication methods, or rate limits for PEPPOL access points are not mentioned [Ref 1].
+
+### Source References
+- [Ref 1] E-invoicing in Sweden — https://e-invoice.eu/sweden/ (Accessed 2024-05-15)


### PR DESCRIPTION
This PR adds the regulatory update for Sweden e-invoicing requirements as of 2025-09-15.

- Introduces 'regulatory-update-20250915-100648.md' detailing PEPPOL BIS Billing 3 recommendations and public sector e-invoicing requirements.
- References: https://e-invoice.eu/sweden/ (Accessed 2024-05-15)